### PR TITLE
sync with master

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,12 +4,18 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from flask_mail import Mail
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
-
 app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app)
 app.secret_key="30bb7cf2-1fef-4d26-83f0-8096b6dcc7a3"
 app.config.from_json('config.json')
+
+loglevel = app.config.get("LOG_LEVEL") if app.config.get("LOG_LEVEL") else "INFO"
+
+numeric_level = getattr(logging, loglevel.upper(), None)
+if not isinstance(numeric_level, int):
+    raise ValueError('Invalid log level: %s' % loglevel)
+
+logging.basicConfig(level=numeric_level)
 
 iam_base_url=app.config['IAM_BASE_URL']
 iam_token_url=iam_base_url + '/token'
@@ -35,4 +41,3 @@ from app import routes, errors
 
 if __name__ == "__main__":
     app.run(host='0.0.0.0')
-

--- a/app/config-sample.json
+++ b/app/config-sample.json
@@ -6,6 +6,8 @@
     "SLAM_URL": "https://indigo-slam.cloud.ba.infn.it:8443",
     "CMDB_URL": "https://indigo-paas.cloud.ba.infn.it/cmdb",
     "IM_URL": "https://indigo-paas.cloud.ba.infn.it/im",
+    "SUPPORT_EMAIL": "support@example.com",
+    "ENABLE_ADVANCED_MENU": "no",
     "TOSCA_TEMPLATES_DIR": "/opt/tosca-templates",
     "TOSCA_PARAMETERS_DIR": "/opt/tosca-parameters",
     "TOSCA_METADATA_DIR": "/opt/tosca-metadata",
@@ -20,5 +22,8 @@
     "MAIL_SENDER": "test@orchestrator.com",
     "ADMINS": "['admin@foo.it','other_admin@test.it']",
     "VAULT_URL": "https://my-vault-instance.com",
-    "SUPPORT_EMAIL": "support@example.com"
+    "SUPPORT_EMAIL": "support@example.com",
+    "EXTERNAL_LINKS": [ { "url": "https://indigo-paas.cloud.ba.infn.it/status-page", "menu_item_name": "Services status" } ],
+    "ENABLE_ADVANCED_MENU": "no",
+    "LOG_LEVEL": "info"
 }

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,11 +1,14 @@
 from flask import render_template, request
 from app import app
 
+@app.errorhandler(403)
+def forbidden(error):
+    return render_template('403.html', message=error.description)
+
 @app.errorhandler(404)
 def page_not_found(error):
 	app.logger.error('Page not found: %s', (request.path))
 	return render_template('404.html'), 404
-
 
 @app.errorhandler(500)
 def internal_server_error(error):

--- a/app/routes.py
+++ b/app/routes.py
@@ -130,7 +130,7 @@ def show_deployments(subject):
 
         headers = {'Authorization': 'bearer %s' % access_token}
 
-        url = orchestratorUrl + "/deployments?createdBy={}&page={}&size={}".format('{}@{}'.format(subject, issuer), 0,
+        url = settings.orchestratorUrl + "/deployments?createdBy={}&page={}&size={}".format('{}@{}'.format(subject, issuer), 0,
                                                                                    999999)
         response = requests.get(url, headers=headers)
 
@@ -483,7 +483,7 @@ def updatedeploymentsstatus(deployments, userid):
                     access_token = iam_blueprint.session.token['access_token']
                     headers = {'Authorization': 'bearer %s' % access_token}
 
-                    url = orchestratorUrl + "/deployments/" + uuid + "/template"
+                    url = settings.orchestratorUrl + "/deployments/" + uuid + "/template"
                     response = requests.get(url, headers=headers)
 
                     if not response.ok:

--- a/app/routes.py
+++ b/app/routes.py
@@ -612,7 +612,7 @@ def home():
                 insert_values = (
                     account_info_json['sub'], account_info_json['name'], account_info_json['preferred_username'],
                     account_info_json['given_name'], account_info_json['family_name'], email,
-                    account_info_json['organisation_name'], avatar(email, 26), role, '1')
+                    account_info_json['organisation_name'], utils.avatar(email, 26), role, '1')
                 cursor.execute(insert_query, insert_values)
                 connection.commit()
             else:

--- a/app/routes.py
+++ b/app/routes.py
@@ -89,7 +89,7 @@ def authorized_with_valid_token(f):
         if not iam_blueprint.session.authorized or 'username' not in session:
            return redirect(url_for('login'))
 
-        if iam_blueprint.session.token['expires_in'] < 20:
+        if iam_blueprint.session.token['expires_in'] < 60:
             app.logger.debug("Force refresh token")
             iam_blueprint.session.get('/userinfo')
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -681,7 +681,7 @@ def depoutput(depid=None):
 
     access_token = iam_blueprint.session.token['access_token']
 
-    if not depid in session['deployments_uuid_array']:
+    if not session['userrole'].lower() == 'admin' and not depid in session['deployments_uuid_array']:
         flash("You are not allowed to browse this page!")
         return redirect(url_for('showdeployments'))
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from app import app, iam_blueprint, iam_base_url, sla as sla, mail
+from app import app, iam_blueprint, sla as sla, mail, settings, utils
 from flask import json, render_template, request, redirect, url_for, flash, session, make_response
 from flask_mail import Message
 import requests
@@ -12,6 +12,7 @@ import sys
 from fnmatch import fnmatch
 from hashlib import md5
 from functools import wraps
+from packaging import version
 import mysql.connector
 from dateutil import parser
 import uuid as uuid_generator
@@ -19,11 +20,7 @@ import uuid as uuid_generator
 # Hashicorp vault support integration
 from app.vault_integration import VaultIntegration
 
-iam_base_url = app.config['IAM_BASE_URL']
-iam_client_id = app.config.get('IAM_CLIENT_ID')
-iam_client_secret = app.config.get('IAM_CLIENT_SECRET')
-
-issuer = iam_base_url
+issuer = settings.iamUrl
 if not issuer.endswith('/'):
     issuer += '/'
 db_host = app.config['DB_HOST']
@@ -32,19 +29,7 @@ db_user = app.config['DB_USER']
 db_password = app.config['DB_PASSWORD']
 db_name = app.config['DB_NAME']
 
-
-def to_pretty_json(value):
-    return json.dumps(value, sort_keys=True,
-                      indent=4, separators=(',', ': '))
-
-
-app.jinja_env.filters['tojson_pretty'] = to_pretty_json
-
-
-def avatar(email, size):
-    digest = md5(email.lower().encode('utf-8')).hexdigest()
-    return 'https://www.gravatar.com/avatar/{}?d=identicon&s={}'.format(digest, size)
-
+app.jinja_env.filters['tojson_pretty'] = utils.to_pretty_json
 
 def getdbconnection():
     cnx = mysql.connector.connect(user=db_user,
@@ -53,88 +38,12 @@ def getdbconnection():
                                   database=db_name)
     return cnx
 
+toscaTemplates = utils.loadToscaTemplates(settings.toscaDir)
+toscaInfo = utils.extractToscaInfo(settings.toscaDir,settings.toscaParamsDir,toscaTemplates,settings.toscaMetadataDir)
 
-toscaDir = app.config.get('TOSCA_TEMPLATES_DIR') + "/"
-tosca_pars_dir = app.config.get('TOSCA_PARAMETERS_DIR')
-tosca_metadata_dir = app.config.get('TOSCA_METADATA_DIR')
-orchestratorUrl = app.config.get('ORCHESTRATOR_URL')
-imUrl = app.config.get('IM_URL')
-
-toscaTemplates = []
-for path, subdirs, files in os.walk(toscaDir):
-    for name in files:
-        if fnmatch(name, "*.yml") or fnmatch(name, "*.yaml"):
-            # skip hidden files
-            if name[0] != '.':
-                toscaTemplates.append(os.path.relpath(os.path.join(path, name), toscaDir))
-
-toscaInfo = {}
-for tosca in toscaTemplates:
-    with io.open( toscaDir + tosca) as stream:
-       template = yaml.full_load(stream)
-
-       toscaInfo[tosca] = {
-                            "valid": True,
-                            "description": "TOSCA Template",
-                            "metadata": {
-                                "icon": "https://cdn4.iconfinder.com/data/icons/mosaicon-04/512/websettings-512.png"
-                            },
-                            "enable_config_form": False,
-                            "inputs": {},
-                            "tabs": {}
-                          }
-
-       if 'topology_template' not in template:
-           toscaInfo[tosca]["valid"] = False
-
-       else:
-
-            if 'description' in template:
-                toscaInfo[tosca]["description"] = template['description']
-
-            if 'metadata' in template and template['metadata'] is not None:
-               for k,v in template['metadata'].items():
-                   toscaInfo[tosca]["metadata"][k] = v
-
-            if tosca_metadata_dir:
-                tosca_metadata_path = tosca_metadata_dir + "/"
-                for mpath, msubs, mnames in os.walk(tosca_metadata_path):
-                    for mname in mnames:
-                        if fnmatch(mname, os.path.splitext(tosca)[0] + '.metadata.yml') or \
-                                 fnmatch(mname, os.path.splitext(tosca)[0] + '.metadata.yaml'):
-                            # skip hidden files
-                            if mname[0] != '.':
-                                tosca_metadata_file = os.path.join(mpath, mname)
-                                with io.open(tosca_metadata_file) as metadata_file:
-                                    metadata_template = yaml.full_load(metadata_file)
-
-                                    if 'metadata' in metadata_template and metadata_template['metadata'] is not None:
-                                        for k,v in metadata_template['metadata'].items():
-                                            toscaInfo[tosca]["metadata"][k] = v
-                             
-            if 'inputs' in template['topology_template']:
-               toscaInfo[tosca]['inputs'] = template['topology_template']['inputs']
-
-            ## add parameters code here
-            tabs = {}
-            if tosca_pars_dir:
-                tosca_pars_path = tosca_pars_dir + "/"  # this has to be reassigned here because is local.
-                for fpath, subs, fnames in os.walk(tosca_pars_path):
-                    for fname in fnames:
-                        if fnmatch(fname, os.path.splitext(tosca)[0] + '.parameters.yml') or \
-                                fnmatch(fname, os.path.splitext(tosca)[0] + '.parameters.yaml'):
-                            # skip hidden files
-                            if fname[0] != '.':
-                                tosca_pars_file = os.path.join(fpath, fname)
-                                with io.open(tosca_pars_file) as pars_file:
-                                    toscaInfo[tosca]['enable_config_form'] = True
-                                    pars_data = yaml.full_load(pars_file)
-                                    toscaInfo[tosca]['inputs'] = pars_data["inputs"]
-                                    if "tabs" in pars_data:
-                                        toscaInfo[tosca]['tabs'] = pars_data["tabs"]
-
-
-app.logger.debug("Extracted TOSCA INFO: " + json.dumps(toscaInfo))
+app.logger.debug("TOSCA INFO: " + json.dumps(toscaInfo))
+app.logger.debug("EXTERNAL_LINKS: " + json.dumps(settings.external_links) )
+app.logger.debug("ENABLE_ADVANCED_MENU: " + str(settings.enable_advanced_menu) )
 
 vault_url = app.config.get('VAULT_URL')
 if vault_url:
@@ -152,6 +61,19 @@ if vault_url:
    vault_delete_token_time_duration = app.config.get("DELETE_TOKEN_TIME_DURATION")
    vault_delete_token_renewal_time_duration = app.config.get("DELETE_TOKEN_RENEWAL_TIME_DURATION")
 
+@app.before_request
+def before_request_checks():
+    if 'external_links' not in session:
+       session['external_links'] = settings.external_links
+    if 'enable_advanced_menu' not in session:
+       session['enable_advanced_menu'] = settings.enable_advanced_menu
+
+def validate_configuration():
+   if not settings.orchestratorConf.get('im_url'):
+       app.logger.debug("Trying to (re)load config from Orchestrator: " + json.dumps(settings.orchestratorConf))
+       access_token = iam_blueprint.session.token['access_token']
+       configuration = utils.getOrchestratorConfiguration(settings.orchestratorUrl, access_token)
+       settings.orchestratorConf = configuration
 
 def authorized_with_valid_token(f):
     @wraps(f)
@@ -165,6 +87,8 @@ def authorized_with_valid_token(f):
             app.logger.debug("Force refresh token")
             iam_blueprint.session.get('/userinfo')
 
+        validate_configuration()
+
         return f(*args, **kwargs)
 
     return decorated_function
@@ -175,9 +99,9 @@ def authorized_with_valid_token(f):
 def show_settings():
 
     return render_template('settings.html',
-                           orchestrator_url=orchestratorUrl,
-                           iam_url=iam_base_url,
-                           im_url=imUrl,
+                           iam_url=settings.iamUrl,
+                           orchestrator_url=settings.orchestratorUrl,
+                           orchestrator_conf=settings.orchestratorConf,
                            vault_url=vault_url)
 
 
@@ -405,7 +329,8 @@ def getslas():
 
     try:
         access_token = iam_blueprint.session.token['access_token']
-        slas = sla.get_slas(access_token)
+        slas = sla.get_slas(access_token, settings.orchestratorConf['slam_url'], settings.orchestratorConf['cdb_url'])
+        print(slas)
 
     except Exception as e:
         flash("Error retrieving SLAs list: \n" + str(e), 'warning')
@@ -643,7 +568,7 @@ def home():
         session['username'] = account_info_json['name']
         session['useremail'] = account_info_json['email']
         session['userrole'] = 'user'
-        session['gravatar'] = avatar(account_info_json['email'], 26)
+        session['gravatar'] = utils.avatar(account_info_json['email'], 26)
         session['organisation_name'] = account_info_json['organisation_name']
         access_token = iam_blueprint.session.token['access_token']
 
@@ -699,7 +624,7 @@ def showdeployments():
 
     headers = {'Authorization': 'bearer %s' % access_token}
 
-    url = orchestratorUrl + "/deployments?createdBy=me&page={}&size={}".format(0, 999999)
+    url = settings.orchestratorUrl + "/deployments?createdBy=me&page={}&size={}".format(0, 999999)
     response = requests.get(url, headers=headers)
 
     deployments = {}
@@ -725,7 +650,7 @@ def deptemplate(depid=None):
     access_token = iam_blueprint.session.token['access_token']
     headers = {'Authorization': 'bearer %s' % access_token}
 
-    url = orchestratorUrl + "/deployments/" + depid + "/template"
+    url = settings.orchestratorUrl + "/deployments/" + depid + "/template"
     response = requests.get(url, headers=headers)
 
     if not response.ok:
@@ -788,7 +713,9 @@ def deplog(physicalId=None):
     access_token = iam_blueprint.session.token['access_token']
     headers = {'Authorization': 'id = im; type = InfrastructureManager; token = %s;' % (access_token)}
 
-    url = imUrl + "/infrastructures/" + physicalId + "/contmsg"
+    app.logger.debug("Configuration: " + json.dumps(settings.orchestratorConf)) 
+
+    url = settings.orchestratorConf['im_url'] + "/infrastructures/" + physicalId + "/contmsg"
     response = requests.get(url, headers=headers)
 
     if not response.ok:
@@ -804,7 +731,7 @@ def depdel(depid=None):
 
     access_token = iam_blueprint.session.token['access_token']
     headers = {'Authorization': 'bearer %s' % access_token}
-    url = orchestratorUrl + "/deployments/" + depid
+    url = settings.orchestratorUrl + "/deployments/" + depid
     response = requests.delete(url, headers=headers)
 
     if not response.ok:
@@ -838,7 +765,7 @@ def configure():
 
     selected_tosca = request.args['selected_tosca']
 
-    slas = sla.get_slas(access_token)
+    slas = sla.get_slas(access_token, settings.orchestratorConf['slam_url'], settings.orchestratorConf['cdb_url'])
 
     ssh_pub_key =  get_ssh_pub_key()
 
@@ -852,12 +779,19 @@ def configure():
 def add_sla_to_template(template, sla_id):
     # Add the placement policy
 
+    if version.parse(utils.getOrchestratorVersion(settings.orchestratorUrl)) >= version.parse("2.2.0-SNAPSHOT"):
+        toscaSlaPlacementType = "tosca.policies.indigo.SlaPlacement"
+    else:
+        toscaSlaPlacementType = "tosca.policies.Placement"
+
     template['topology_template']['policies'] = [
-        {"deploy_on_specific_site": {"type": "tosca.policies.Placement", "properties": {"sla_id": sla_id}}}]
+           {"deploy_on_specific_site": { "type": toscaSlaPlacementType, "properties": {"sla_id": sla_id}}}]
+
     app.logger.debug(yaml.dump(template, default_flow_style=False))
+
     return template
-
-
+#        
+# 
 @app.route('/submit', methods=['POST'])
 @authorized_with_valid_token
 def createdep():
@@ -867,7 +801,7 @@ def createdep():
 
     app.logger.debug("Form data: " + json.dumps(request.form.to_dict()))
 
-    with io.open(toscaDir + request.args.get('template')) as stream:
+    with io.open(settings.toscaDir + request.args.get('template')) as stream:
         template = yaml.load(stream)
         # rewind file
         stream.seek(0)
@@ -919,7 +853,7 @@ def createdep():
 
     # body= json.dumps(payload)
 
-    url = orchestratorUrl + "/deployments/"
+    url = settings.orchestratorUrl + "/deployments/"
     headers = {'Content-Type': 'application/json', 'Authorization': 'bearer %s' % access_token}
     # response = requests.post(url, data=body, headers=headers)
     response = requests.post(url, json=payload, params=params, headers=headers)

--- a/app/routes.py
+++ b/app/routes.py
@@ -19,6 +19,9 @@ import uuid as uuid_generator
 
 # Hashicorp vault support integration
 from app.vault_integration import VaultIntegration
+iam_base_url = settings.iamUrl
+iam_client_id = settings.iamClientID
+iam_client_secret = settings.iamClientSecret
 
 issuer = settings.iamUrl
 if not issuer.endswith('/'):
@@ -45,6 +48,8 @@ app.logger.debug("TOSCA INFO: " + json.dumps(toscaInfo))
 app.logger.debug("EXTERNAL_LINKS: " + json.dumps(settings.external_links) )
 app.logger.debug("ENABLE_ADVANCED_MENU: " + str(settings.enable_advanced_menu) )
 
+#______________________________________
+# vault section
 vault_url = app.config.get('VAULT_URL')
 if vault_url:
    app.config.from_json('vault-config.json')
@@ -747,8 +752,7 @@ def depdel(depid=None):
 
 def delete_secret_from_vault(access_token, secret_path):
 
-    vault = VaultIntegration(vault_url, iam_base_url, iam_client_id, iam_client_secret, vault_bound_audience,
-                             access_token, vault_secrets_path)
+    vault = VaultIntegration(vault_url, iam_base_url, iam_client_id, iam_client_secret, vault_bound_audience, access_token, vault_secrets_path)
 
     auth_token = vault.get_auth_token()
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -698,12 +698,10 @@ def depoutput(depid=None):
         # inp = json.dumps(dep['inputs'])
         inp = dep[
             'inputs']  # we keep this as json, to retrieve info to enable passphrase recovery from vault only for those deployment has storage_encryption enabled
-        links = json.dumps(dep['links'])
         return render_template('depoutput.html',
                                deployment=dep,
                                inputs=inp,
-                               outputs=output,
-                               links=links)
+                               outputs=output)
 
 
 @app.route('/templatedb/<depid>')

--- a/app/routes.py
+++ b/app/routes.py
@@ -813,7 +813,7 @@ def createdep():
     app.logger.debug("Form data: " + json.dumps(request.form.to_dict()))
 
     with io.open(settings.toscaDir + request.args.get('template')) as stream:
-        template = yaml.load(stream)
+        template = yaml.full_load(stream)
         # rewind file
         stream.seek(0)
         template_text = stream.read()

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,24 @@
+from app import app
+
+toscaDir = app.config['TOSCA_TEMPLATES_DIR'] + "/"
+toscaParamsDir = app.config.get('TOSCA_PARAMETERS_DIR')
+toscaMetadataDir = app.config.get('TOSCA_METADATA_DIR')
+orchestratorUrl = app.config['ORCHESTRATOR_URL']
+
+iamUrl = app.config['IAM_BASE_URL']
+iamClientID = app.config.get('IAM_CLIENT_ID')
+iamClientSecret = app.config.get('IAM_CLIENT_SECRET')
+
+tempSlamUrl = app.config.get('SLAM_URL') if app.config.get('SLAM_URL') else "" 
+
+orchestratorConf = {
+  'cdb_url': app.config.get('CMDB_URL'),
+  'slam_url': tempSlamUrl + "/rest/slam",
+  'im_url': app.config.get('IM_URL')
+}
+
+external_links = app.config.get('EXTERNAL_LINKS') if app.config.get('EXTERNAL_LINKS') else []
+
+enable_advanced_menu = app.config.get('ENABLE_ADVANCED_MENU') if app.config.get('ENABLE_ADVANCED_MENU') else "no"
+
+iamGroups = app.config.get('IAM_GROUP_MEMBERSHIP')

--- a/app/sla.py
+++ b/app/sla.py
@@ -1,14 +1,10 @@
 import requests, json
 from flask import session
-from app import app
 
-slam_cert = app.config.get('SLAM_CERT')
-slamUrl = app.config.get('SLAM_URL')
-cmdbUrl = app.config.get('CMDB_URL')
 
-def get_sla_extra_info(access_token, service_id):
+def get_sla_extra_info(access_token, service_id, cmdb_url):
     headers = {'Authorization': 'bearer %s' % (access_token)}
-    url = cmdbUrl + "/service/id/" + service_id
+    url = cmdb_url + "/service/id/" + service_id
     response = requests.get(url, headers=headers, timeout=20)
     response.raise_for_status()
 
@@ -20,25 +16,19 @@ def get_sla_extra_info(access_token, service_id):
 
     return sitename, service_type
 
-def get_slas(access_token):
+def get_slas(access_token, slam_url, cmdb_url):
 
     headers = {'Authorization': 'bearer %s' % (access_token)}
 
-    app.logger.debug(slamUrl)
-
-    url = slamUrl + "/rest/slam/preferences/" + session['organisation_name']
-    verify = True
-    if slam_cert:
-        verify = slam_cert
-    response = requests.get(url, headers=headers, timeout=20, verify=verify)
-    app.logger.debug("SLA response status: " + str(response.status_code))
+    url = slam_url + "/preferences/" + session['organisation_name']
+    
+    response = requests.get(url, headers=headers, timeout=20, verify=False)
 
     response.raise_for_status()
-    app.logger.debug("SLA response: " + json.dumps(response.json()))
     slas = response.json()['sla']
 
     for i in range(len(slas)):
-       sitename, service_type = get_sla_extra_info(access_token,slas[i]['services'][0]['service_id'])
+       sitename, service_type = get_sla_extra_info(access_token,slas[i]['services'][0]['service_id'], cmdb_url)
        slas[i]['service_type']=service_type
        slas[i]['sitename']=sitename
 

--- a/app/templates/403.html
+++ b/app/templates/403.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+
+<div class="container-fluid">
+
+    <br>
+
+    <div class="card shadow mb-4">
+        <div class="card-header py-3">
+          <div class="row">
+            <div class="col-md-6">
+              <!-- Title -->
+              <h1 class="font-weight-bold text-primary">Oops!</h1>
+	      <h2> 403 Forbidden </h2>
+            </div>
+          </div> <!-- / .row -->
+        </div>
+        <div class="card-body">
+          <div class="alert alert-primary">
+            <h4>Sorry, you are not authorized.</h4>
+            {% if message %}
+	      <p>{{ message }}</p>
+	    {% endif %}
+          </div>
+          <div>
+              <button onclick='location.href="{{ url_for('logout') }}"' class="btn btn-primary btn-lg"><span class="fas fa-sign-out-alt"></span>
+                  Logout </button>
+          </div>
+  	</div> 
+    </div>
+</div>
+
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -67,6 +67,7 @@
                 <ul class="navbar-nav mr-auto">
                     {% if session['username'] %}
                     <li class="nav-item active"><a class="nav-link" href="{{ url_for("showdeployments") }}">Deployments</a></li>
+                    {% if session['enable_advanced_menu'] == "yes" %}
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">Advanced</a>
                         <div class="dropdown-menu">
@@ -74,6 +75,17 @@
                             <a class="dropdown-item" href="{{ url_for("show_settings") }}">Settings</a>
                         </div>
                     </li>
+                    {% endif %}
+		    {% if session["external_links"]|length > 0 %}
+		    <li class="nav-item dropdown">
+			<a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">External Links</a>
+                        <div class="dropdown-menu">
+			    {% for link in session["external_links"] %}
+			      <a class="dropdown-item" href="{{ link.url }}">{{link.menu_item_name}}</a>
+			    {% endfor %}
+                        </div>
+                    </li>
+		    {% endif %}
                     {% if session['userrole'] == 'admin' %}
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('show_users') }}">Users</a></li>
                     {% endif %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -112,3 +112,9 @@
     {% include 'footer.html' %}
 </body>
 </html>
+
+<style>
+body {
+  margin-bottom: 70px
+}	  
+</style>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -81,7 +81,7 @@
 			<a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">External Links</a>
                         <div class="dropdown-menu">
 			    {% for link in session["external_links"] %}
-			      <a class="dropdown-item" href="{{ link.url }}">{{link.menu_item_name}}</a>
+			      <a class="dropdown-item" href="{{ link.url }}" target="blank">{{link.menu_item_name}}</a>
 			    {% endfor %}
                         </div>
                     </li>
@@ -109,5 +109,6 @@
         </div>
     </nav>
     {% block content %}{% endblock %}
+    {% include 'footer.html' %}
 </body>
 </html>

--- a/app/templates/config_form.html
+++ b/app/templates/config_form.html
@@ -13,7 +13,9 @@
 {% else %}
   <li class="nav-item"><a class="nav-link" data-toggle="tab" href=#InputValues>Input Values</a></li>
 {% endif %}
+{% if session['enable_advanced_menu'] == "yes" %}
 <li class="nav-item"><a class="nav-link" data-toggle="tab" href=#Advanced>Advanced</a></li> <!-- always create advanced tab -->
+{% endif %}
 </ul>
   <!-- end tab creation section -->
 

--- a/app/templates/config_form.html
+++ b/app/templates/config_form.html
@@ -11,7 +11,7 @@
     {% endif %}
   {% endfor %}
 {% else %}
-  <li class="nav-item"><a class="nav-link" data-toggle="tab" href=#InputValues>Input Values</a></li>
+  <li class="nav-item"><a class="nav-link active" data-toggle="tab" href=#InputValues>Input Values</a></li>
 {% endif %}
 {% if session['enable_advanced_menu'] == "yes" %}
 <li class="nav-item"><a class="nav-link" data-toggle="tab" href=#Advanced>Advanced</a></li> <!-- always create advanced tab -->
@@ -39,7 +39,7 @@
     {% endfor %}
 
   {% else %} <!-- no tabs -->
-    <div id=InputValues class="tab-pane fade in active">
+    <div id=InputValues class="tab-pane fade show active">
       {% for key, value in inputs.items() %}
         {% include 'input_types.html' %}
       {% endfor %}

--- a/app/templates/createdep.html
+++ b/app/templates/createdep.html
@@ -23,7 +23,7 @@
               <hr>
               <p>To create a new ssh key pair or upload your public key, please go <a href="{{ url_for("ssh_keys") }}">here</a></p>
               <p>You can still provide a key in the dedicated field of the form.</p>
-              <p>For more information, please visit our <a href="https://laniakea.readthedocs.io/en/latest/qs_key_pair.html" target="_blank">documentation page</a>.</p>
+              <p>For more information, please visit our <a href="https://laniakea.readthedocs.io/en/latest/user_documentation/ssh_keys/ssh_keys.html" target="_blank">documentation page</a>.</p>
               </div>
               <div class="modal-footer">
                   <div class="d-flex flex-grow-1 justify-content-start custom-control custom-checkbox">

--- a/app/templates/default_form.html
+++ b/app/templates/default_form.html
@@ -1,7 +1,9 @@
 <!-- start tabs creation section -->
 <ul class="nav nav-tabs">
   <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#InputValues">Input Values</a></li>
+  {% if session['enable_advanced_menu'] == "yes" %}
   <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#Advanced">Advanced</a></li>
+  {% endif %}
 </ul>
 <!-- end tab creation section -->
 <div class="tab-content">

--- a/app/templates/default_form.html
+++ b/app/templates/default_form.html
@@ -8,13 +8,25 @@
 <!-- end tab creation section -->
 <div class="tab-content">
 {% set inputs=template['inputs'] %}
-    <!-- inputs -->
+    <!-- inputs -->
   <div class="tab-pane fade show active" id=InputValues>
     {% if inputs|length > 0 %}
       {% for key, value in inputs.items() %}
         <div class="form-group">
           <label for="{{key}}">{{key}}</label>
+
+	  <!-- select type if constraints are defined -->
+	  {% set constraints = value.constraints | selectattr('valid_values') | map(attribute='valid_values') | list  %}
+	  {% if constraints %}
+	  <select class="js-example-basic-single js-states form-control" id="{{key}}" name="{{key}}">
+          {% for val in constraints[0] %}
+             <option value="{{val}}">{{val}}</option>
+          {% endfor %}
+          </select>
+	  {% else %}
+	  <!-- text type, hide fields with password -->
           <input {% if 'password' in key %}type="password"{% else %}type="text"{% endif %} class="form-control" id="{{key}}" name="{{key}}" value="{{value.default}}" aria-describedby="help{{key}}" {% if value.required %}required{%endif%} />
+	  {% endif %}
           <span id="help{{key}}" class="help-block">{{value.description}}</span>
         </div>
       {% endfor %}

--- a/app/templates/dep_user.html
+++ b/app/templates/dep_user.html
@@ -34,7 +34,7 @@
             </div>
             <div class="col-md-6 text-right">
               <!-- Button -->
-              <button class="btn btn-small btn-outline-secondary" onclick="location.href='{{ url_for("getslas") }}'"><span class="fas fa-sync"></span> Refresh</button>
+              <button class="btn btn-small btn-outline-secondary" onclick="location.href='{{ url_for('show_deployments', subject=user.sub) }}'"><span class="fas fa-sync"></span> Refresh</button>
               <button type=button class="btn btn-small btn-outline-secondary" onclick="location.href='{{ url_for('show_users') }}'"><span class="fas fa-arrow-left mr-2"></span> Back</button>
             </div>
           </div> <!-- / .row -->

--- a/app/templates/depoutput.html
+++ b/app/templates/depoutput.html
@@ -45,32 +45,34 @@
           <p><b>ENDPOINT</b> {{deployment.endpoint}}</p>
 
           {% if deployment.status == 'CREATE_COMPLETE' %} <!-- Display these options only if the deployment is complete -->
-          <!-- Vault integration  if -->
-          {% if 'storage_encryption' in inputs and inputs['storage_encryption'] == 'True' %}
-          <hr/>
-          <button type=button id="retrieveBtn" class="btn btn-small btn-outline-success" onclick="getVaultSecret( href='{{ url_for('read_secret_from_vault', depid=deployment.uuid) }}' )">
-            <span class="fas fa-lock mr-2"></span>Retrieve LUKS passphrase
-          </button>
-          <!-- Modal Retrieve luks passphrase-->
-          <div class="modal fade" id="newModal">
-            <div class="modal-dialog">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <h5 class="modal-title" id="get_luks_passwd_label_{{deployment.uuid}}">LUKS passphrase</h5>
-                  <button type="button" class="close" data-dismiss="modal">&times;</button>
-                </div>
-                <div class="modal-body">
-                <input id="luksPassphrase" class="form-control" type="password">
-                </div>
-                <div class="modal-footer">
-                  <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                  <!--button type="button" class="btn btn-success" onclick="copyToClipboard()" data-dismiss="modal"><span class="fas fa-copy"></span> Copy to clipboard</button-->
+            {% if session['userid'] == deployment.createdBy['subject'] %} <!-- Show encryption info only if the deployment belong to user (thus avoiding admin) -->
+              <!-- Vault integration  if -->
+              {% if 'storage_encryption' in inputs and inputs['storage_encryption'] == 'True' %}
+              <hr/>
+              <button type=button id="retrieveBtn" class="btn btn-small btn-outline-success" onclick="getVaultSecret( href='{{ url_for('read_secret_from_vault', depid=deployment.uuid) }}' )">
+                <span class="fas fa-lock mr-2"></span>Retrieve LUKS passphrase
+              </button>
+              <!-- Modal Retrieve luks passphrase-->
+              <div class="modal fade" id="newModal">
+                <div class="modal-dialog">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h5 class="modal-title" id="get_luks_passwd_label_{{deployment.uuid}}">LUKS passphrase</h5>
+                      <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    </div>
+                    <div class="modal-body">
+                    <input id="luksPassphrase" class="form-control" type="password">
+                    </div>
+                    <div class="modal-footer">
+                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                      <!--button type="button" class="btn btn-success" onclick="copyToClipboard()" data-dismiss="modal"><span class="fas fa-copy"></span> Copy to clipboard</button-->
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
-          </div>
-          {% endif %}<!-- End encryption volume status if -->
-          {% endif %}<!-- End instance status if -->
+              {% endif %} <!-- End encryption volume status if -->
+            {% endif %} <!-- end if user session -->
+          {% endif %} <!-- End instance status if -->
         </div>
         <div class="tab-pane fade" id="InputValues">
           <br>

--- a/app/templates/depoutput.html
+++ b/app/templates/depoutput.html
@@ -83,7 +83,7 @@
       </div>
 
     </div>
-
+  </div>
 </div>
 
 <script>

--- a/app/templates/depoutput.html
+++ b/app/templates/depoutput.html
@@ -29,7 +29,6 @@
         <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#DeploymentStatus">Overview</a></li>
         <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#InputValues">Input values</a></li>
         <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#OutputValues">Output values</a></li>
-        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#Links">Links</a></li>
       </ul>
 
 
@@ -80,9 +79,6 @@
         <div class="tab-pane fade" id="OutputValues">
           <br>
           <pre>{{ outputs | safe }}</pre>
-        </div>
-        <div class="tab-pane fade" id="Links">
-          <pre>{{ links | safe }}</pre>
         </div>
       </div>
 

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -1,0 +1,51 @@
+<footer class="footer">
+  <div class="container-fluid">
+    <div class="row my-2">
+	    <div class="col-md-4 my-0">© 2019 DEEP Hybrid DataCloud<br> 
+		    <p style="color:white;font-size:10px;">This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No 777435.</p>
+	    </div>
+	<div class="col-md-6 my-0">
+	  <p>	
+	     <img src="https://deep-hybrid-datacloud.eu/wp-content/uploads/sites/2/2018/01/logo_EUC-1.png"/>
+	  </p>   
+	</div>
+	<div class="col-md-2 mt-4" style="display:flex;justify-content:space-around;">
+		<a href="https://twitter.com/DEEP_eu" target="_blank" alt="Twitter" title="Twitter">
+                  <i class="fab fa-twitter" style="color:white;"></i>
+		</a>
+		<a href="https://www.linkedin.com/groups/12093546" target="_blank" alt="Linkedin" title="Linkedin">
+                  <i class="fab fa-linkedin" style="color:white;"></i>
+		</a>
+		<a href="https://github.com/deephdc/" target="_blank" alt="Github" title="Github">
+                  <i class="fab fa-github" style="color:white;"></i>
+	        </a>
+		<a href="https://hub.docker.com/u/deephdc/" target="_blank" alt="DockerHub" title="DockerHub">
+                  <i class="fab fa-docker" style="color:white;"></i>
+		</a>
+		<a href="https://www.researchgate.net/project/DEEP-Hybrid-DataCloud" target="_blank" alt="ResearchGate" title="ResearchGate">
+                  <i class="fab fa-researchgate" style="color:white;"></i>
+		</a>
+		<a href="https://docs.deep-hybrid-datacloud.eu/" target="_blank" alt="Documentation" title="Documentation">
+                  <i class="fa fa-book" style="color:white;"></i>
+		</a>
+	</div>    
+    </div>
+  </div>	  
+</footer>
+
+
+<style>
+/* Sticky footer styles
+-------------------------------------------------- */
+.footer {
+  position: fixed; 
+  bottom: 0;
+  width: 100%;
+  height: 70px;  /* Set the fixed height of the footer */
+  line-height: 20px; 
+  background-color: #262727;
+  color: white;	     
+  opacity: 0.80;	   
+}
+</style>
+

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -47,5 +47,9 @@
   color: white;	     
   opacity: 0.80;	   
 }
-</style>
 
+.footer img {
+height: 55px;
+}
+
+</style>

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-
+<div class="container-fluid">
 <div class="container mt-2" id="cardsContainer" xmlns="http://www.w3.org/1999/html">
     <div class="input-group mb-4">
       <div class="input-group-prepend">
@@ -43,6 +43,7 @@
     {% if templates|count % 3 != 1 %}
     </div>
     {% endif %}
+</div>
 </div>
 
 <script>
@@ -102,6 +103,7 @@ $(".tosca-descr").dotdotdot({
   color: white;
   //font-family: 'Abel', sans-serif;
   //font-family: 'Roboto Condensed', sans-serif;
+  opacity: 0.90;
 }
 
 

--- a/app/templates/portfolio.html
+++ b/app/templates/portfolio.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<div class="container-fluid">
+
 <div class="container mt-2" id="cardsContainer" xmlns="http://www.w3.org/1999/html">
     <div class="input-group mb-4">
       <div class="input-group-prepend">
@@ -40,10 +40,9 @@
     </div>
     {% endif %}
     {% endfor %}
-    {% if templates|count % 3 != 1 %}
+    {% if templates|count % 3 != 0 %}
     </div>
     {% endif %}
-</div>
 </div>
 
 <script>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -22,20 +22,24 @@
             </thead>
             <tbody>
                 <tr>
-                    <td>IAM</td>
+                    <td>Identity and Access Management (IAM)</td>
                     <td>{{ iam_url }}</td>
                 </tr>
                 <tr>
-                    <td>Orchestrator</td>
+                    <td>PaaS Orchestrator</td>
                     <td>{{ orchestrator_url }}</td>
                 </tr>
-                <tr>
-                    <td>Infrastructure Manager</td>
-                    <td>{{ im_url }}</td>
+		<tr>
+		    <td>Infrastructure Manager (IM)</td>
+                    <td>{{ orchestrator_conf['im_url'] }}</td>
                 </tr>
-                <tr>
-                    <td>Hashicorp Vault</td>
-                    <td>{{ vault_url }}</td>
+		<tr>
+                    <td>SLA Manager (SLAM)</td>
+                    <td>{{ orchestrator_conf['slam_url'] }}</td>
+                </tr>
+		<tr>
+                    <td>Configuration Management DB (CMDB)</td>
+                    <td>{{ orchestrator_conf['cdb_url'] }}</td>
                 </tr>
             </tbody>
         </table>

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,113 @@
+import json, yaml, requests, os, io
+from fnmatch import fnmatch
+from hashlib import md5
+
+def to_pretty_json(value):
+    return json.dumps(value, sort_keys=True,
+                      indent=4, separators=(',', ': '))
+
+def avatar(email, size):
+  digest = md5(email.lower().encode('utf-8')).hexdigest()
+  return 'https://www.gravatar.com/avatar/{}?d=identicon&s={}'.format(digest, size)
+
+
+def getOrchestratorVersion(orchestrator_url):
+    url = orchestrator_url +  "/info"
+    response = requests.get(url)
+
+    return response.json()['build']['version']
+
+
+def getOrchestratorConfiguration(orchestrator_url, access_token):
+    
+    headers = {'Authorization': 'bearer %s' % (access_token)}
+
+    url = orchestrator_url +  "/configuration"
+    response = requests.get(url, headers=headers)
+
+    configuration = {}
+    if response.ok:
+        configuration = response.json()
+
+    return configuration
+
+def loadToscaTemplates(directory):
+
+   toscaTemplates = []
+   for path, subdirs, files in os.walk(directory):
+      for name in files:
+           if fnmatch(name, "*.yml") or fnmatch(name, "*.yaml"):
+               # skip hidden files
+               if name[0] != '.':
+                  toscaTemplates.append( os.path.relpath(os.path.join(path, name), directory ))
+
+   return toscaTemplates
+
+
+def extractToscaInfo(toscaDir, tosca_pars_dir, toscaTemplates, tosca_metadata_dir):
+    toscaInfo = {}
+    for tosca in toscaTemplates:
+        with io.open( toscaDir + tosca) as stream:
+           template = yaml.full_load(stream)
+    
+           toscaInfo[tosca] = {
+                                "valid": True,
+                                "description": "TOSCA Template",
+                                "metadata": {
+                                    "icon": "https://cdn4.iconfinder.com/data/icons/mosaicon-04/512/websettings-512.png"
+                                },
+                                "enable_config_form": False,
+                                "inputs": {},
+                                "tabs": {}
+                              }
+    
+           if 'topology_template' not in template:
+               toscaInfo[tosca]["valid"] = False
+    
+           else:
+    
+                if 'description' in template:
+                    toscaInfo[tosca]["description"] = template['description']
+    
+                if 'metadata' in template and template['metadata'] is not None:
+                   for k,v in template['metadata'].items():
+                       toscaInfo[tosca]["metadata"][k] = v
+
+                if tosca_metadata_dir:
+                    tosca_metadata_path = tosca_metadata_dir + "/"
+                    for mpath, msubs, mnames in os.walk(tosca_metadata_path):
+                        for mname in mnames:
+                            if fnmatch(mname, os.path.splitext(tosca)[0] + '.metadata.yml') or \
+                                     fnmatch(mname, os.path.splitext(tosca)[0] + '.metadata.yaml'):
+                                # skip hidden files
+                                if mname[0] != '.':
+                                    tosca_metadata_file = os.path.join(mpath, mname)
+                                    with io.open(tosca_metadata_file) as metadata_file:
+                                        metadata_template = yaml.full_load(metadata_file)
+
+                                        if 'metadata' in metadata_template and metadata_template['metadata'] is not None:
+                                            for k,v in metadata_template['metadata'].items():
+                                                toscaInfo[tosca]["metadata"][k] = v
+    
+                if 'inputs' in template['topology_template']:
+                   toscaInfo[tosca]['inputs'] = template['topology_template']['inputs']
+    
+                ## add parameters code here
+                tabs = {}
+                if tosca_pars_dir:
+                    tosca_pars_path = tosca_pars_dir + "/"  # this has to be reassigned here because is local.
+                    for fpath, subs, fnames in os.walk(tosca_pars_path):
+                        for fname in fnames:
+                            if fnmatch(fname, os.path.splitext(tosca)[0] + '.parameters.yml') or \
+                                    fnmatch(fname, os.path.splitext(tosca)[0] + '.parameters.yaml'):
+                                # skip hidden files
+                                if fname[0] != '.':
+                                    tosca_pars_file = os.path.join(fpath, fname)
+                                    with io.open(tosca_pars_file) as pars_file:
+                                        toscaInfo[tosca]['enable_config_form'] = True
+                                        pars_data = yaml.full_load(pars_file)
+                                        toscaInfo[tosca]['inputs'] = pars_data["inputs"]
+                                        if "tabs" in pars_data:
+                                            toscaInfo[tosca]['tabs'] = pars_data["tabs"]
+
+    return toscaInfo

--- a/app/vault_integration.py
+++ b/app/vault_integration.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Hashicorp Vault management class
 Currently supported kv secrets engine - version 2 (https://www.vaultproject.io/api/secret/kv/kv-v2.html#delete-metadata-and-all-versions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Flask-Mail==0.9.1
 mysql-connector==2.2.9
 python-dateutil==2.8.0
 cryptography==2.7
+packaging==19.2


### PR DESCRIPTION
Implemented the following changes:
- if the Orchestrator exposes the /configuration endpoint, this will be used to set the PaaS services URLs (overriding the values passed in the config.json, if provided)
- the menu has been extended to include also external links
- code re-organized in auxiliary modules (setting, utils, etc.)
- Added template for 403 error page
- Handling input constraints
- Configurable advanced menu
