### PR TITLE
Improved outputs and sla view

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -73,6 +73,14 @@ def getslas():
   return render_template('sla.html', slas=slas)
 
 
+def check_template_access(allowed_groups, user_groups):
+
+    #check intersection of user groups with user membership
+    if (set(allowed_groups)&set(user_groups)) != set() or allowed_groups == ['*']:
+        return True
+    else:
+        return False
+
 @app.route('/')
 def home():
     if not iam_blueprint.session.authorized:
@@ -82,9 +90,9 @@ def home():
 
     if account_info.ok:
         account_info_json = account_info.json()
+        user_groups = account_info_json['groups']
 
         if settings.iamGroups:
-            user_groups = account_info_json['groups']
             if not set(settings.iamGroups).issubset(user_groups):
                 app.logger.debug("No match on group membership. User group membership: " + json.dumps(user_groups))
                 message = Markup('You need to be a member of the following IAM groups: {0}. <br> Please, visit <a href="{1}">{1}</a> and apply for the requested membership.'.format(json.dumps(settings.iamGroups), settings.iamUrl))
@@ -95,8 +103,9 @@ def home():
         session['organisation_name'] = account_info_json['organisation_name']
         access_token = iam_blueprint.token['access_token']
 
-        return render_template('portfolio.html', templates=toscaInfo)
-
+        templates = { k:v for (k,v) in toscaInfo.items() if check_template_access(v.get("metadata").get("allowed_groups"),user_groups) }
+        return render_template('portfolio.html', templates=templates)
+        
 
 @app.route('/deployments')
 @authorized_with_valid_token

--- a/app/routes.py
+++ b/app/routes.py
@@ -76,7 +76,7 @@ def getslas():
 def check_template_access(allowed_groups, user_groups):
 
     #check intersection of user groups with user membership
-    if (set(allowed_groups)&set(user_groups)) != set() or allowed_groups == ['*']:
+    if (set(allowed_groups.split(','))&set(user_groups)) != set() or allowed_groups == '*':
         return True
     else:
         return False

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -72,7 +72,7 @@
 		    <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">Advanced</a>
                         <div class="dropdown-menu">
-                            <a class="dropdown-item" href="{{ url_for("getslas") }}">SLAs</a>
+                            <a class="dropdown-item" href="{{ url_for("getslas") }}">Resource Providers</a>
                             <a class="dropdown-item" href="{{ url_for("show_settings") }}">Settings</a>
 			</div>
 		    </li>

--- a/app/templates/createdep.html
+++ b/app/templates/createdep.html
@@ -10,7 +10,7 @@
     <div class="card shadow mb-4">
         <div class="card-header py-3">
             <h4 class="font-weight-bold text-primary">
-            Template: {{selectedTemplate}}
+            {% if template['metadata']['display_name'] is defined %}{{template['metadata']['display_name']}}{% else %}{{selectedTemplate}}{% endif %}
             </h4>
         </div>
 

--- a/app/templates/deployments.html
+++ b/app/templates/deployments.html
@@ -121,7 +121,12 @@
                                         <div class="tab-pane pl-3 pt-3 fade border border-primary" id="outputs{{deployment.uuid}}" role="tabpanel" aria-labelledby="tab-outputs{{deployment.uuid}}">
                                             <!--p><small><pre>{{deployment.outputs | tojson_pretty() | safe }}</pre></small></p-->
                                             {% for k,v in deployment.outputs.items() %}
-                                            <p><small><strong>{{k}}</strong>: {{v}}</small></p>
+					    {% if k == "node_creds" %}
+					    <p><small><strong>ssh_private_key</strong>: <pre>{{ v['token'] | replace("\\n", "\n") }}</pre></small></p>
+				            <p><small><strong>ssh_login</strong>: {{ v['user'] }}</small></p>		    
+					    {% else %}    
+					    <p><small><strong>{{k}}</strong>: {{v}}</small></p>
+					    {% endif %}
                                             {% endfor %}
                                         </div>
                                     </div>

--- a/app/templates/deployments.html
+++ b/app/templates/deployments.html
@@ -124,6 +124,8 @@
 					    {% if k == "node_creds" %}
 					    <p><small><strong>ssh_private_key</strong>: <pre>{{ v['token'] | replace("\\n", "\n") }}</pre></small></p>
 				            <p><small><strong>ssh_login</strong>: {{ v['user'] }}</small></p>		    
+					    {% elif "endpoint" in k %}
+					    <p><small><strong>{{k}}</strong>: <a href="{{v}}" target="_blank">{{v}}</a></small></p>
 					    {% else %}    
 					    <p><small><strong>{{k}}</strong>: {{v}}</small></p>
 					    {% endif %}

--- a/app/templates/deployments.html
+++ b/app/templates/deployments.html
@@ -121,9 +121,9 @@
                                         <div class="tab-pane pl-3 pt-3 fade border border-primary" id="outputs{{deployment.uuid}}" role="tabpanel" aria-labelledby="tab-outputs{{deployment.uuid}}">
                                             <!--p><small><pre>{{deployment.outputs | tojson_pretty() | safe }}</pre></small></p-->
                                             {% for k,v in deployment.outputs.items() %}
-					    {% if k == "node_creds" %}
-					    <p><small><strong>ssh_private_key</strong>: <pre>{{ v['token'] | replace("\\n", "\n") }}</pre></small></p>
-				            <p><small><strong>ssh_login</strong>: {{ v['user'] }}</small></p>		    
+					    {% if "node_creds" in k %}
+					    <p><small><strong>{{k}}.ssh_private_key</strong>: <pre>{{ v['token'] | replace("\\n", "\n") }}</pre></small></p>
+					    <p><small><strong>{{k}}.ssh_login</strong>: {{ v['user'] }}</small></p>		    
 					    {% elif "endpoint" in k %}
 					    <p><small><strong>{{k}}</strong>: <a href="{{v}}" target="_blank">{{v}}</a></small></p>
 					    {% else %}    

--- a/app/templates/sla.html
+++ b/app/templates/sla.html
@@ -11,7 +11,7 @@
           <div class="row">
             <div class="col-md-6">
               <!-- Title -->
-              <h4 class="font-weight-bold text-primary">Service Level Agreements</h4>
+              <h4 class="font-weight-bold text-primary">Resource Providers</h4>
             </div>
             <div class="col-md-6 text-right">
               <!-- Button -->
@@ -28,8 +28,7 @@
 	            <!-- <th>id</th>-->
                     <th>Site</th>
                     <th>Service Type</th>
-                    <th>Start date</th>
-                    <th>End date</th>
+                    <th>Service endpoint</th>
                 </tr>
             </thead>
             <tbody>
@@ -38,8 +37,7 @@
 	            <!-- <td>{{sla.id}}</td>-->
 	            <td>{{sla.sitename}}</td>
 	            <td>{{sla.service_type}}</td>
-	            <td>{{sla.start_date}}</td>
-	            <td>{{sla.end_date}}</td>
+	            <td>{{sla.endpoint}}</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -57,7 +55,7 @@
           "targets"  : 'no-sort',
           "orderable": false,
         }],
-        "order": [[ 3, "asc" ]]
+        "order": [[ 0, "asc" ]]
     });
 </script>
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -37,7 +37,7 @@ def loadToscaTemplates(directory):
 
    toscaTemplates = []
    for path, subdirs, files in os.walk(directory):
-      for name in files:
+      for name in sorted(files):
            if fnmatch(name, "*.yml") or fnmatch(name, "*.yaml"):
                # skip hidden files
                if name[0] != '.':
@@ -56,7 +56,8 @@ def extractToscaInfo(toscaDir, tosca_pars_dir, toscaTemplates):
                                 "valid": True,
                                 "description": "TOSCA Template",
                                 "metadata": {
-                                    "icon": "https://cdn4.iconfinder.com/data/icons/mosaicon-04/512/websettings-512.png"
+                                    "icon": "https://cdn4.iconfinder.com/data/icons/mosaicon-04/512/websettings-512.png",
+                                    "allowed_groups": ['*']
                                 },
                                 "enable_config_form": False,
                                 "inputs": {},

--- a/app/utils.py
+++ b/app/utils.py
@@ -57,7 +57,7 @@ def extractToscaInfo(toscaDir, tosca_pars_dir, toscaTemplates):
                                 "description": "TOSCA Template",
                                 "metadata": {
                                     "icon": "https://cdn4.iconfinder.com/data/icons/mosaicon-04/512/websettings-512.png",
-                                    "allowed_groups": ['*']
+                                    "allowed_groups": '*'
                                 },
                                 "enable_config_form": False,
                                 "inputs": {},


### PR DESCRIPTION
- Improved visualization of the outputs:
   - the ssh key is now formatted
   - the endpoints are active links
- New SLA page with more useful information
- Added control on the access to the templates depending on the user IAM groups 
